### PR TITLE
PR #1: Added class skeletons, unit tests, and additional libraries

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,8 @@ libraryDependencies ++= Seq(
   "org.scalatest"  %% "scalatest"  % "3.2.19"  % Test,
   "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,
   "org.slf4j" % "slf4j-simple" % "2.0.13",
-  "org.log4s" %% "log4s" % "1.10.0"
+  "org.log4s" %% "log4s" % "1.10.0",
+  "com.lihaoyi" %% "mainargs" % "0.7.5",
 )
 
 enablePlugins(JavaAppPackaging)

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,9 @@ scalacOptions += "@.scalacOptions.txt"
 
 libraryDependencies ++= Seq(
   "org.scalatest"  %% "scalatest"  % "3.2.19"  % Test,
-  "org.scalacheck" %% "scalacheck" % "1.18.0" % Test
+  "org.scalacheck" %% "scalacheck" % "1.18.1" % Test,
+  "org.slf4j" % "slf4j-simple" % "2.0.13",
+  "org.log4s" %% "log4s" % "1.10.0"
 )
 
 enablePlugins(JavaAppPackaging)

--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -1,0 +1,1 @@
+org.slf4j.simpleLogger.defaultLogLevel = debug

--- a/src/main/scala/hellotest/ConcreteOutputObserver.scala
+++ b/src/main/scala/hellotest/ConcreteOutputObserver.scala
@@ -4,11 +4,12 @@ import scala.collection.mutable
 class ConcreteOutputObserver extends OutputObserver:
   override def output(cloud: mutable.Map[String, Int]): Unit = 
   {
-    
+    // DO: call convert function and print result to the standard output for the user
   }
 
   override def convert(cloud: mutable.Map[String, Int]): String = 
   {
+    // DO: convert the given map object into a string representation and return it
     ""
   }
 end ConcreteOutputObserver

--- a/src/main/scala/hellotest/ConcreteOutputObserver.scala
+++ b/src/main/scala/hellotest/ConcreteOutputObserver.scala
@@ -2,12 +2,14 @@ package hellotest
 import scala.collection.mutable
 
 class ConcreteOutputObserver extends OutputObserver:
-  override def output(cloud: mutable.Map[String, Int]): Unit = 
+  override type Result = mutable.Map[String, Int]
+  
+  override def output(cloud: Result): Unit =
   {
     // DO: call convert function and print result to the standard output for the user
   }
 
-  override def convert(cloud: mutable.Map[String, Int]): String = 
+  override def convert(cloud: Result): String =
   {
     // DO: convert the given map object into a string representation and return it
     ""

--- a/src/main/scala/hellotest/ConcreteOutputObserver.scala
+++ b/src/main/scala/hellotest/ConcreteOutputObserver.scala
@@ -1,0 +1,15 @@
+package hellotest
+import scala.collection.mutable
+
+class ConcreteOutputObserver extends OutputObserver:
+  override def output(cloud: mutable.Map[String, Int]): Unit = 
+  {
+    
+  }
+
+  override def convert(cloud: mutable.Map[String, Int]): String = 
+  {
+    ""
+  }
+end ConcreteOutputObserver
+

--- a/src/main/scala/hellotest/Main.scala
+++ b/src/main/scala/hellotest/Main.scala
@@ -1,13 +1,17 @@
 package hellotest
 
 import org.log4s.*
-import org.log4s.Logger.DebugLevelLogger
+import mainargs.{main, arg, ParserForMethods, Flag}
 
 object Main:
 
-  def main(args: Array[String]): Unit =
+  @main
+  def run(@arg(short = 'c', doc = "size of the sliding word cloud") cloudSize: Int = 10,
+          @arg(short = 'l', doc = "minimum word length to be considered") minLength: Int = 6,
+          @arg(short = 'w', doc = "size of the sliding FIFO queue") windowSize: Int = 1000) =
+  {
     val logger = org.log4s.getLogger("logger")
-    logger.debug(f"argument count: ${args.length}")
+    logger.debug(f"cloudSize: ${cloudSize}, minLength: ${minLength}, windowSize: ${windowSize}")
 
     val lines = scala.io.Source.stdin.getLines()
 
@@ -16,11 +20,13 @@ object Main:
       lines.flatMap(l => l.split("(?U)[^\\p{Alpha}0-9']+"))
     }
 
-    for (word <- words)
-    {
+    for (word <- words) {
       println("word: " + word)
       if scala.sys.process.stdout.checkError() then
         sys.exit(1)
     }
+  }
+
+  def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args.toIndexedSeq)
 
 end Main

--- a/src/main/scala/hellotest/Main.scala
+++ b/src/main/scala/hellotest/Main.scala
@@ -2,8 +2,18 @@ package hellotest
 
 object Main:
 
-  def main(args: Array[String]) = 
-    println("Hello scalatest!")
-    println(s"Today's date is ${java.time.LocalDate.now}.")
+  def main(args: Array[String]) =
+    val lines = scala.io.Source.stdin.getLines()
+
+    val words = {
+      import scala.language.unsafeNulls
+      lines.flatMap(l => l.split("(?U)[^\\p{Alpha}0-9']+"))
+    }
+
+    for (word <- words)
+    {
+      println("word: " + word)
+      if scala.sys.process.stdout.checkError() then sys.exit(1)
+    }
 
 end Main

--- a/src/main/scala/hellotest/Main.scala
+++ b/src/main/scala/hellotest/Main.scala
@@ -8,7 +8,7 @@ object Main:
   @main
   def run(@arg(short = 'c', doc = "size of the sliding word cloud") cloudSize: Int = 10,
           @arg(short = 'l', doc = "minimum word length to be considered") minLength: Int = 6,
-          @arg(short = 'w', doc = "size of the sliding FIFO queue") windowSize: Int = 1000) =
+          @arg(short = 'w', doc = "size of the sliding FIFO queue") windowSize: Int = 1000): Unit =
   {
     val logger = org.log4s.getLogger("logger")
     logger.debug(f"cloudSize: ${cloudSize}, minLength: ${minLength}, windowSize: ${windowSize}")
@@ -20,11 +20,10 @@ object Main:
       lines.flatMap(l => l.split("(?U)[^\\p{Alpha}0-9']+"))
     }
 
-    for (word <- words) {
-      println("word: " + word)
-      if scala.sys.process.stdout.checkError() then
-        sys.exit(1)
-    }
+    val wordCloud = new WordCloud(cloudSize, minLength, windowSize)
+    val outputObserver = new ConcreteOutputObserver()
+
+    wordCloud.process(words, outputObserver)
   }
 
   def main(args: Array[String]): Unit = ParserForMethods(this).runOrExit(args.toIndexedSeq)

--- a/src/main/scala/hellotest/Main.scala
+++ b/src/main/scala/hellotest/Main.scala
@@ -1,8 +1,14 @@
 package hellotest
 
+import org.log4s.*
+import org.log4s.Logger.DebugLevelLogger
+
 object Main:
 
-  def main(args: Array[String]) =
+  def main(args: Array[String]): Unit =
+    val logger = org.log4s.getLogger("logger")
+    logger.debug(f"argument count: ${args.length}")
+
     val lines = scala.io.Source.stdin.getLines()
 
     val words = {
@@ -13,7 +19,8 @@ object Main:
     for (word <- words)
     {
       println("word: " + word)
-      if scala.sys.process.stdout.checkError() then sys.exit(1)
+      if scala.sys.process.stdout.checkError() then
+        sys.exit(1)
     }
 
 end Main

--- a/src/main/scala/hellotest/OutputObserver.scala
+++ b/src/main/scala/hellotest/OutputObserver.scala
@@ -1,0 +1,7 @@
+package hellotest
+
+trait OutputObserver {
+  def output(cloud: scala.collection.mutable.Map[String,Int]): Unit
+  
+  def convert(cloud: scala.collection.mutable.Map[String, Int]): String
+}

--- a/src/main/scala/hellotest/OutputObserver.scala
+++ b/src/main/scala/hellotest/OutputObserver.scala
@@ -1,7 +1,9 @@
 package hellotest
 
 trait OutputObserver {
-  def output(cloud: scala.collection.mutable.Map[String,Int]): Unit
+  type Result
+
+  def output(result: Result): Unit
   
-  def convert(cloud: scala.collection.mutable.Map[String, Int]): String
+  def convert(result: Result): String
 }

--- a/src/main/scala/hellotest/WordCloud.scala
+++ b/src/main/scala/hellotest/WordCloud.scala
@@ -1,0 +1,12 @@
+package hellotest
+
+class WordCloud(c: Int, l: Int, w: Int) {
+  private val cloudSize = c
+  private val minLength = l
+  private val windowSize = w
+
+  def process(input: Iterator[String], output: OutputObserver): Unit = 
+  {
+    // DO: create word cloud from given iterator and call observer so it can display result to user
+  }
+}

--- a/src/test/scala/hellotest/TestOutputObserver.scala
+++ b/src/test/scala/hellotest/TestOutputObserver.scala
@@ -1,0 +1,18 @@
+package hellotest
+
+import org.scalatest.funsuite.AnyFunSuite
+
+class TestOutputObserver extends AnyFunSuite:
+  test("empty map should be converted into empty string"):
+    val outputObserver = new ConcreteOutputObserver()
+    val result = outputObserver.convert(scala.collection.mutable.Map[String,Int]())
+
+    assert(result == "")
+
+  test("non-empty map should be converted into non-empty string"):
+    val outputObserver = new ConcreteOutputObserver()
+    val result = outputObserver.convert(scala.collection.mutable.Map[String, Int](("bb", 2), ("aa", 2), ("cc",1)))
+
+    assert(result == "bb: 2 aa: 2 cc: 1")
+
+end TestOutputObserver

--- a/src/test/scala/hellotest/TestWordCloud.scala
+++ b/src/test/scala/hellotest/TestWordCloud.scala
@@ -1,0 +1,47 @@
+package hellotest
+
+import org.scalatest.funsuite.AnyFunSuite
+import scala.collection.mutable
+
+
+class TestWordCloud extends AnyFunSuite:
+  test("should have an empty count"):
+    val wordCloud = new WordCloud(10, 6, 1000)
+    val input = List()
+    val output = new OutputToList()
+
+    wordCloud.process(input.iterator, output)
+
+    assert(output.list.isEmpty)
+
+  test("should have a non-empty count"):
+    val wordCloud = new WordCloud(3, 2, 5)
+    val input = List("a", "b", "c", "aa", "bb", "cc", "aa", "bb", "aa", "bb", "a", "b", "c", "a", "a", "a")
+    val output = new OutputToList()
+
+    wordCloud.process(input.iterator, output)
+
+    assert(output.list(0) == mutable.Map[String, Int](("bb", 2), ("aa", 2), ("cc", 1)))
+    assert(output.list(1) == mutable.Map[String, Int](("bb", 2), ("aa", 2), ("cc", 1)))
+    assert(output.list(2) == mutable.Map[String, Int](("bb", 2), ("aa", 2), ("cc", 1)))
+    assert(output.list(3) == mutable.Map[String, Int](("aa", 3), ("bb", 2)))
+    assert(output.list(4) == mutable.Map[String, Int](("aa", 3), ("bb", 2)))
+    assert(output.list(5) == mutable.Map[String, Int](("aa", 4), ("bb", 1)))
+end TestWordCloud
+
+class OutputToList extends OutputObserver:
+  override type Result = mutable.Map[String,Int]
+
+  val list: mutable.Queue[mutable.Map[String, Int]] = mutable.Queue[mutable.Map[String, Int]]()
+
+  override def output(cloud: Result): Unit =
+  {
+    list.append(cloud.clone())
+  }
+
+  override def convert(cloud: Result): String =
+  {
+    ""
+  }
+end OutputToList
+


### PR DESCRIPTION
Added Libraries for QOL:
  1. mainargs: parses command-line arguments more easily
  2. log4s: used for logging information outside the standard output, which is reserved for the user

Created skeleton for the output observer and word cloud classes:

- WordCloud
  - the function `process` takes an iterator and the output observer implementation. The goal is to create a map that counts the words from the user
  
- ConcreteOutputObserver
  - the goal of the function `output` is to print out the resulting string
  - the goal of the function `convert` is to convert the map given by the WordCloud object into a string that can be printed out in the standard output
 
Created unit tests for both classes